### PR TITLE
Introduce GitHub Action to test resolvability of external links [DOC-253]

### DIFF
--- a/.github/workflows/test-external-links.yml
+++ b/.github/workflows/test-external-links.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
       - uses: hazelcast/hz-docs/.github/actions/test-external-links@main
         with:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DOCS }}

--- a/.github/workflows/test-external-links.yml
+++ b/.github/workflows/test-external-links.yml
@@ -1,0 +1,15 @@
+name: Test external links
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * 1" # Runs at 12:00, only on Monday
+     
+jobs:
+  test-external-links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: hazelcast/hz-docs/.github/actions/test-external-links@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DOCS }}


### PR DESCRIPTION
Introduces [functionality introduced in `hz-docs`](https://github.com/hazelcast/hz-docs/pull/1382) to rest of docs codebase.

Post-merge checklist:
- [x] add `SLACK_WEBHOOK` secret to repo