### PR TITLE
Fix dead security links

### DIFF
--- a/docs/modules/ROOT/pages/security.adoc
+++ b/docs/modules/ROOT/pages/security.adoc
@@ -3,4 +3,4 @@
 You can use TLS/SSL to secure the communication between the JDBC driver and the cluster.
 TLS/SSL must be enabled and configured both on the driver and cluster sides.
 
-See xref:configuration.adoc#ssl-prop[TLS/SSL Properties] for the descriptions of the JDBC driver configuration elements, and xref:hazelcast:security:tls-ssl.adoc[TLS/SSL for Members] to configure the cluster side.
+See https://github.com/hazelcast/hazelcast-jdbc#ssl-properties[TLS/SSL Properties] for the descriptions of the JDBC driver configuration elements, and xref:hazelcast:security:tls-ssl.adoc[TLS/SSL for Members] to configure the cluster side.


### PR DESCRIPTION
Link to the `jdbc-driver`'s `README` as this is the only source of TLS/SSL information I can find.